### PR TITLE
Add lint for Rust `std::env::current_dir` call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,8 +17,11 @@ version = "0.1.0"
 dependencies = [
  "cc",
  "clap",
+ "env_logger",
+ "log",
  "tree-sitter",
  "tree-sitter-bash",
+ "tree-sitter-rust",
  "walkdir",
 ]
 
@@ -52,6 +55,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +68,7 @@ checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
 dependencies = [
  "atty",
  "bitflags",
+ "clap_derive",
  "indexmap",
  "lazy_static",
  "os_str_bytes",
@@ -68,10 +78,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_derive"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -81,6 +123,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "indexmap"
@@ -105,6 +153,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
+name = "log"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,6 +174,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
+dependencies = [
+ "proc-macro2",
 ]
 
 [[package]]
@@ -152,6 +251,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "syn"
+version = "1.0.90"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +295,28 @@ dependencies = [
  "cc",
  "tree-sitter",
 ]
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784f7ef9cdbd4c895dc2d4bb785e95b4a5364a602eec803681db83d1927ddf15"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,19 @@ name = "arbsego"
 version = "0.1.0"
 edition = "2021"
 
+
 [dependencies]
-clap = { version = "3.1.6", features = ["cargo"] }
+clap = { version = "3.1.6", features = ["derive"] }
+
+log = "0.4.16"
+env_logger = "0.9.0"
+
+walkdir = "2.3.2"
+
 tree-sitter = "0.19"
 tree-sitter-bash = "0.19.0"
-walkdir = "2.3.2"
+tree-sitter-rust = "0.19.0"
+
 
 [build-dependencies]
 cc="*"

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,0 +1,37 @@
+use crate::FileType;
+
+use std::path::{Path, PathBuf};
+
+#[derive(Debug)]
+pub struct File {
+    path_buf: PathBuf,
+    file_type: FileType,
+}
+
+impl From<PathBuf> for File {
+    fn from(path_buf: PathBuf) -> Self {
+        let file_type = FileType::from(path_buf.as_path());
+        Self {
+            path_buf,
+            file_type,
+        }
+    }
+}
+
+impl File {
+    pub fn file_type(&self) -> FileType {
+        self.file_type
+    }
+}
+
+impl AsRef<Path> for File {
+    fn as_ref(&self) -> &Path {
+        self.path()
+    }
+}
+
+impl File {
+    pub fn path(&self) -> &Path {
+        self.path_buf.as_path()
+    }
+}

--- a/src/file_type.rs
+++ b/src/file_type.rs
@@ -1,0 +1,27 @@
+use std::path::Path;
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum FileType {
+    BashSource,
+    RustSource,
+    Other,
+}
+
+impl From<&Path> for FileType {
+    fn from(path: &Path) -> Self {
+        let file_name: &str = path.file_name().unwrap().to_str().unwrap();
+        if file_name.ends_with(".sh") {
+            FileType::BashSource
+        } else if file_name.ends_with(".rs") {
+            FileType::RustSource
+        } else {
+            FileType::Other
+        }
+    }
+}
+
+impl FileType {
+    pub fn has_lints(&self) -> bool {
+        self != &Self::Other
+    }
+}

--- a/src/languages.rs
+++ b/src/languages.rs
@@ -1,0 +1,24 @@
+use crate::FileType;
+
+use tree_sitter::Language;
+
+pub struct Languages {
+    bash: Language,
+    rust: Language,
+}
+
+impl Languages {
+    pub fn new() -> Self {
+        let bash = tree_sitter_bash::language();
+        let rust = tree_sitter_rust::language();
+        Self { bash, rust }
+    }
+
+    pub fn language_from_file_type(&self, file_type: FileType) -> Option<Language> {
+        match file_type {
+            FileType::BashSource => Some(self.bash),
+            FileType::RustSource => Some(self.rust),
+            FileType::Other => None,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,23 @@
+pub mod options;
+pub use crate::options::*;
+
 pub mod run;
 pub use crate::run::{run, RunResult};
 
-mod run_result;
+mod languages;
+use languages::Languages;
 
-pub mod options;
-pub use crate::options::*;
+mod file;
+use file::File;
+
+mod file_type;
+use file_type::FileType;
+
+mod lint;
+use lint::Lint;
+mod lints;
+
+mod r#match;
+use r#match::Match;
+
+mod run_result;

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -1,0 +1,9 @@
+use crate::{FileType, Match};
+
+use tree_sitter::Node;
+
+pub trait Lint {
+    fn file_type(&self) -> FileType;
+
+    fn matches(&self, node: &Node, source: &[u8]) -> Option<Box<dyn Match>>;
+}

--- a/src/lints/apt_call.rs
+++ b/src/lints/apt_call.rs
@@ -1,0 +1,48 @@
+use crate::{FileType, Lint, Match};
+
+use tree_sitter::Node;
+
+pub struct AptCall {}
+
+impl Lint for AptCall {
+    fn file_type(&self) -> FileType {
+        FileType::BashSource
+    }
+
+    /// Return if the node is a bash command which calls apt.
+    fn matches(&self, node: &Node, source: &[u8]) -> Option<Box<dyn Match>> {
+        if node.kind() != "command" {
+            return None;
+        }
+
+        let name: Node = node.child_by_field_name("name").unwrap();
+        let name = name.utf8_text(source).unwrap();
+
+        if name == "apt" {
+            return Some(Box::new(AptCallMatch {}));
+        }
+
+        if name == "sudo" {
+            match node.child_by_field_name("argument") {
+                Some(node) => {
+                    if node.utf8_text(source).unwrap() == "apt" {
+                        Some(Box::new(AptCallMatch {}))
+                    } else {
+                        None
+                    }
+                }
+                None => None,
+            }
+        } else {
+            None
+        }
+    }
+}
+
+struct AptCallMatch {}
+
+impl Match for AptCallMatch {
+    fn message(&self) -> String {
+        String::from("`apt` call in a Bash script.")
+    }
+}

--- a/src/lints/current_dir.rs
+++ b/src/lints/current_dir.rs
@@ -1,0 +1,52 @@
+use crate::{FileType, Lint, Match};
+
+use tree_sitter::Node;
+
+pub struct CurrentDir {}
+
+impl Lint for CurrentDir {
+    fn file_type(&self) -> FileType {
+        FileType::RustSource
+    }
+
+    // TODO: Properly resolve the function that is being called in order to _really_ check if the
+    // function is `std::env::current_dir`.
+    fn matches(&self, node: &Node, source: &[u8]) -> Option<Box<dyn Match>> {
+        if node.kind() != "call_expression" {
+            return None;
+        }
+
+        let function: Node = node.child_by_field_name("function").unwrap();
+        if function.kind() != "scoped_identifier" {
+            return None;
+        }
+
+        let path: Node = function.child_by_field_name("path").unwrap();
+        let path: &str = path.utf8_text(source).unwrap();
+        if path != "env" {
+            return None;
+        }
+
+        let name: Node = function.child_by_field_name("name").unwrap();
+        let name: &str = name.utf8_text(source).unwrap();
+        if name != "current_dir" {
+            return None;
+        }
+
+        Some(Box::new(CurrentDirMatch::new()))
+    }
+}
+
+struct CurrentDirMatch {}
+
+impl CurrentDirMatch {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Match for CurrentDirMatch {
+    fn message(&self) -> String {
+        String::from("`std::env::current_dir` calls `getcwd()` on Linux which canonicalizes paths by resolving `.`, `..`, and symlinks. This might not be the desired behavior.")
+    }
+}

--- a/src/lints/mod.rs
+++ b/src/lints/mod.rs
@@ -1,0 +1,5 @@
+mod apt_call;
+pub use apt_call::AptCall;
+
+mod current_dir;
+pub use current_dir::CurrentDir;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,16 +4,38 @@ use std::env;
 use std::path::PathBuf;
 use std::process;
 
-use clap::{arg, command, ArgMatches as Arguments, Command as Parser};
+use clap::Parser;
+
+use env_logger::Builder;
+
+use log::LevelFilter as LogLevel;
+
+#[derive(Parser)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    /// Enable debug logging
+    #[clap(long)]
+    debug: bool,
+
+    /// Paths to run on
+    paths: Vec<String>,
+}
 
 fn main() {
-    let parser: Parser = parser();
-    let arguments: Arguments = parser.get_matches();
+    let args = Args::parse();
+
+    let log_level = match args.debug {
+        true => LogLevel::Debug,
+        false => LogLevel::Off,
+    };
+    set_up_logging(log_level);
 
     let current_dir = env::current_dir().unwrap();
-    let paths: Vec<PathBuf> = match arguments.values_of("paths") {
-        Some(paths) => paths.map(PathBuf::from).collect(),
-        None => vec![current_dir.clone()],
+
+    let paths: Vec<PathBuf> = if args.paths.is_empty() {
+        vec![current_dir.clone()]
+    } else {
+        args.paths.iter().map(PathBuf::from).collect()
     };
 
     let options = Options::new(current_dir, paths);
@@ -24,7 +46,7 @@ fn main() {
     }
 }
 
-/// Return a command line interface (CLI) argument parser.
-fn parser() -> Parser<'static> {
-    command!().arg(arg!([paths] "Paths to run on").multiple_values(true))
+/// Set up logging.
+fn set_up_logging(level: LogLevel) {
+    Builder::new().filter_level(level).init();
 }

--- a/src/match.rs
+++ b/src/match.rs
@@ -1,0 +1,3 @@
+pub trait Match {
+    fn message(&self) -> String;
+}


### PR DESCRIPTION
Add a lint for calls to `std::env::current_dir` in Rust because on Linux
it calls `getcwd()` which canonicalizes paths by resolving `.`, `..`, and
symlinks which might not be be the desired behavior.